### PR TITLE
automatically lint with `shellcheck`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: shell
+script:
+  - bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: shell
 script:
-  - bash -c 'shopt -s globstar nullglob; shellcheck **/*.{sh,ksh,bash}'
+  - bash -c 'shopt -s globstar nullglob; shellcheck img2djvu'


### PR DESCRIPTION
Please, setup the CI - I recomment GitHub Actions for GitHub repo.
There you can statically check the script, like you can observe here: https://travis-ci.com/Anton-Latukha/img2djvu/jobs/245838710

For example block of code:
```bash
( #...
  if [ "$useocr" -gt 0 ] ; then
     printf "Starting OCR...\n"
     ocrodjvu --engine "$ocrengine" --language "$ocrlanguage" --jobs "$ocrjobs" --in-place --on-error=resume "$djvu"
  fi
) && rm -rf "$tmpdir" || (
  printf "Failure\nTemporary directory left: %s\n" "$tmpdir"
  exit 2
)
```

Used as if:
```
(A)
  && B
  || C
```

Was:
```
if A
  then B
  else C
```

But in `shell` that code is:
```
do C
if A
  then B
  else return exitcode of C
```

Actions `C` in shell here executed in parallel to `A`, and as so - executes and does things every time.

`shellcheck` is a very good code linter and most things it suggests is a good code practice. 
It has a knowledge DB wiki with examples and explanations.

It is also very useful to run it locally as: `shellcheck ./script`.